### PR TITLE
Supported more export types in getUtilities()

### DIFF
--- a/.changeset/upset-facts-behave.md
+++ b/.changeset/upset-facts-behave.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-add-missing-tests": minor
+---
+
+Supported more export types in getUtilities()

--- a/src/utils/create-tests/get-utilities.ts
+++ b/src/utils/create-tests/get-utilities.ts
@@ -64,7 +64,9 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
         }
 
         default: {
-          throw new Error(`Unknown type: ${declaration.type}`);
+          console.error(`ERROR: Unknown type: ${declaration.type}`);
+          console.log(file);
+          console.log();
         }
       }
 
@@ -124,8 +126,9 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
               }
 
               default: {
-                console.log(id);
-                throw new Error(`Unknown ID type: ${id.type}`);
+                console.log(`ERROR: Unknown ID type: ${id.type}`);
+                console.log(file);
+                console.log();
               }
             }
           });
@@ -134,7 +137,9 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
         }
 
         default: {
-          throw new Error(`Unknown type: ${declaration.type}`);
+          console.error(`ERROR: Unknown type: ${declaration.type}`);
+          console.log(file);
+          console.log();
         }
       }
 

--- a/src/utils/create-tests/get-utilities.ts
+++ b/src/utils/create-tests/get-utilities.ts
@@ -52,6 +52,7 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
           break;
         }
 
+        case 'TSDeclareFunction':
         case 'TSInterfaceDeclaration':
         case 'TSTypeAliasDeclaration': {
           break;
@@ -94,6 +95,7 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
           break;
         }
 
+        case 'TSDeclareFunction':
         case 'TSInterfaceDeclaration':
         case 'TSTypeAliasDeclaration': {
           break;

--- a/src/utils/create-tests/get-utilities.ts
+++ b/src/utils/create-tests/get-utilities.ts
@@ -52,6 +52,11 @@ export function getUtilities(file: string, data: Data): Utilities | undefined {
           break;
         }
 
+        case 'ObjectExpression': {
+          utilities.default.push(camelize(data.entityName));
+          break;
+        }
+
         case 'TSDeclareFunction':
         case 'TSInterfaceDeclaration':
         case 'TSTypeAliasDeclaration': {


### PR DESCRIPTION
## Background

Found a couple of examples that causes `getUtilities()` to error.
